### PR TITLE
Improve the running of the generated example.exe program part of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ This package was inspired by [https://github.com/intridea/omniauth](https://gith
 
 ## Installation
 
-```text
-$ go get github.com/markbates/goth
-```
+$ `text go get github.com/markbates/goth`
 
 ## Supported Providers
 
@@ -89,21 +87,21 @@ through Twitter, Facebook, Google Plus etc.
 To run the example use either of the methods below ::
 
 1. Clone the source from GitHub
-   $ `text git clone git@github.com:markbates/goth.git`
-   $ `text cd goth/examples`
-   $ `text go get -v`
-   $ `text go build`
+   $ `text git clone git@github.com:markbates/goth.git`  
+   $ `text cd goth/examples`  
+   $ `text go get -v`  
+   $ `text go build`  
    $ `text ./examples`
 
 or use
 
-2. Get the repository as a dependency
-   $ `text go get github.com/markbates/goth`
-   $ `text cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples`
-   $ `text cd goth/examples`
-   $ `text go get -v`
-   $ `text go build`
-   $ `text ./examples`
+2. Get the repository as a dependency  
+   $ `text go get github.com/markbates/goth`  
+   $ `text cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples`  
+   $ `text cd goth/examples`  
+   $ `text go get -v`  
+   $ `text go build`  
+   $ `text ./examples`  
    Note: The version of the goth `goth@v1.80.0` in the path above is subject to change in the future
 
 Now open up your browser and go to [http://localhost:3000](http://localhost:3000) to see the example.

--- a/README.md
+++ b/README.md
@@ -16,95 +16,106 @@ $ go get github.com/markbates/goth
 
 ## Supported Providers
 
-* Amazon
-* Apple
-* Auth0
-* Azure AD
-* Battle.net
-* Bitbucket
-* Box
-* ClassLink
-* Cloud Foundry
-* Dailymotion
-* Deezer
-* DigitalOcean
-* Discord
-* Dropbox
-* Eve Online
-* Facebook
-* Fitbit
-* Gitea
-* GitHub
-* Gitlab
-* Google
-* Google+ (deprecated)
-* Heroku
-* InfluxCloud
-* Instagram
-* Intercom
-* Kakao
-* Lastfm
-* LINE
-* Linkedin
-* Mailru
-* Meetup
-* MicrosoftOnline
-* Naver
-* Nextcloud
-* Okta
-* OneDrive
-* OpenID Connect (auto discovery)
-* Oura
-* Patreon
-* Paypal
-* Reddit
-* SalesForce
-* Shopify
-* Slack
-* Soundcloud
-* Spotify
-* Steam
-* Strava
-* Stripe
-* TikTok
-* Tumblr
-* Twitch
-* Twitter
-* Typetalk
-* Uber
-* VK
-* WeCom
-* Wepay
-* Xero
-* Yahoo
-* Yammer
-* Yandex
-* Zoom
+- Amazon
+- Apple
+- Auth0
+- Azure AD
+- Battle.net
+- Bitbucket
+- Box
+- ClassLink
+- Cloud Foundry
+- Dailymotion
+- Deezer
+- DigitalOcean
+- Discord
+- Dropbox
+- Eve Online
+- Facebook
+- Fitbit
+- Gitea
+- GitHub
+- Gitlab
+- Google
+- Google+ (deprecated)
+- Heroku
+- InfluxCloud
+- Instagram
+- Intercom
+- Kakao
+- Lastfm
+- LINE
+- Linkedin
+- Mailru
+- Meetup
+- MicrosoftOnline
+- Naver
+- Nextcloud
+- Okta
+- OneDrive
+- OpenID Connect (auto discovery)
+- Oura
+- Patreon
+- Paypal
+- Reddit
+- SalesForce
+- Shopify
+- Slack
+- Soundcloud
+- Spotify
+- Steam
+- Strava
+- Stripe
+- TikTok
+- Tumblr
+- Twitch
+- Twitter
+- Typetalk
+- Uber
+- VK
+- WeCom
+- Wepay
+- Xero
+- Yahoo
+- Yammer
+- Yandex
+- Zoom
 
 ## Examples
 
 See the [examples](examples) folder for a working application that lets users authenticate
 through Twitter, Facebook, Google Plus etc.
 
-To run the example either clone the source from GitHub
+To run the example use either of the methods below ::
 
-```text
-$ git clone git@github.com:markbates/goth.git
-```
+1. Clone the source from GitHub
+   $ `text git clone git@github.com:markbates/goth.git`
+   $ `text cd goth/examples`
+   $ `text go get -v`
+   $ `text go build`
+   $ `text ./examples`
+
 or use
-```text
-$ go get github.com/markbates/goth
-```
-```text
-$ cd goth/examples
-$ go get -v
-$ go build
-$ ./examples
-```
+
+2. Get the repository as a dependency
+   $ `text go get github.com/markbates/goth`
+   $ `text cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples`
+   $ `text cd goth/examples`
+   $ `text go get -v`
+   $ `text go build`
+   $ `text ./examples`
+   Note: The version of the goth `goth@v1.80.0` in the path above is subject to change in the future
 
 Now open up your browser and go to [http://localhost:3000](http://localhost:3000) to see the example.
 
-To actually use the different providers, please make sure you set environment variables. Example given in the examples/main.go file
+Most likely error screen will appear for most of the options when clicked on. To actually use the different providers, please make sure you set environment variables before running the built Go program (example.exe in this case).
+
+Environment variables can be set using
+$ `text export key=value`
+
+For example, To set the environment variables for GOOGLE sign-in use where the respective value of the GOOGLE_KEY and GOOGLE_SECRET. These can be found/created using the google cloud console.
+$ `text export GOOGLE_KEY=your_google_client_id`
+$ `text export GOOGLE_SECRET=your_google_secret_key`
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ export GOOGLE_KEY=your_google_client_id
 export GOOGLE_SECRET=your_google_secret_key
 ```
 
-After copying each code
-
 ## Security Notes
 
 By default, gothic uses a `CookieStore` from the `gorilla/sessions` package to store session data.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This package was inspired by [https://github.com/intridea/omniauth](https://gith
 
 ## Installation
 
+Paste the following command in the terminal
+
 ```text
-$ go get github.com/markbates/goth
+go get github.com/markbates/goth
 ```
 
 ## Supported Providers
@@ -88,9 +90,9 @@ through Twitter, Facebook, Google Plus etc.
 
 To run the example use either of the methods below ::
 
-1. Clone the source from GitHub
+1. Clone the source from GitHub - (copy and paste the whole command line block from below in the terminal)
    ```text
-   $ git clone git@github.com:markbates/goth.git
+   git clone git@github.com:markbates/goth.git
    cd goth/examples
    go get -v
    go build
@@ -99,9 +101,9 @@ To run the example use either of the methods below ::
 
 or use
 
-2. Get the repository as a dependency
+2. Get the repository as a dependency - (copy and paste the whole command line block from below in the terminal)
    ```text
-   $ go get github.com/markbates/goth
+   go get github.com/markbates/goth
    cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples
    cd goth/examples
    go get -v
@@ -117,15 +119,17 @@ Most likely error screen will appear for most of the options when clicked on. To
 Environment variables can be set using
 
 ```text
-$ export key=value
+export key=value
 ```
 
 For example, To set the environment variables for GOOGLE sign-in use where the respective value of the GOOGLE_KEY and GOOGLE_SECRET. These can be found/created using the google cloud console.
 
 ```text
-$ export GOOGLE_KEY=your_google_client_id
+export GOOGLE_KEY=your_google_client_id
 export GOOGLE_SECRET=your_google_secret_key
 ```
+
+After copying each code
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This package was inspired by [https://github.com/intridea/omniauth](https://gith
 
 ## Installation
 
-$ `text go get github.com/markbates/goth`
+```text
+$ go get github.com/markbates/goth
+```
 
 ## Supported Providers
 
@@ -87,21 +89,25 @@ through Twitter, Facebook, Google Plus etc.
 To run the example use either of the methods below ::
 
 1. Clone the source from GitHub
-   $ `text git clone git@github.com:markbates/goth.git`  
-   $ `text cd goth/examples`  
-   $ `text go get -v`  
-   $ `text go build`  
-   $ `text ./examples`
+   ```text
+   $ git clone git@github.com:markbates/goth.git
+   cd goth/examples
+   go get -v
+   go build
+   ./examples
+   ```
 
 or use
 
-2. Get the repository as a dependency  
-   $ `text go get github.com/markbates/goth`  
-   $ `text cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples`  
-   $ `text cd goth/examples`  
-   $ `text go get -v`  
-   $ `text go build`  
-   $ `text ./examples`  
+2. Get the repository as a dependency
+   ```text
+   $ go get github.com/markbates/goth
+   cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples
+   cd goth/examples
+   go get -v
+   go build
+   ./examples
+   ```
    Note: The version of the goth `goth@v1.80.0` in the path above is subject to change in the future
 
 Now open up your browser and go to [http://localhost:3000](http://localhost:3000) to see the example.
@@ -109,11 +115,17 @@ Now open up your browser and go to [http://localhost:3000](http://localhost:3000
 Most likely error screen will appear for most of the options when clicked on. To actually use the different providers, please make sure you set environment variables before running the built Go program (example.exe in this case).
 
 Environment variables can be set using
-$ `text export key=value`
+
+```text
+$ export key=value
+```
 
 For example, To set the environment variables for GOOGLE sign-in use where the respective value of the GOOGLE_KEY and GOOGLE_SECRET. These can be found/created using the google cloud console.
-$ `text export GOOGLE_KEY=your_google_client_id`
-$ `text export GOOGLE_SECRET=your_google_secret_key`
+
+```text
+$ export GOOGLE_KEY=your_google_client_id
+export GOOGLE_SECRET=your_google_secret_key
+```
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Environment variables can be set using following command in the terminal
 export key=value
 ```
 
-For example, To set the environment variables for GOOGLE sign-in use where the respective value of the GOOGLE_KEY and GOOGLE_SECRET. These can be found/created using the google cloud console.
+For example, To enable Google Sign-in, set the environment variables `GOOGLE_KEY` and `GOOGLE_SECRET` to their corresponding values. Obtain these credentials from Google Cloud Console.
 
 ```text
 export GOOGLE_KEY=your_google_client_id

--- a/README.md
+++ b/README.md
@@ -105,12 +105,11 @@ or use
    ```text
    go get github.com/markbates/goth
    cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples
-   cd goth/examples
    go get -v
    go build
    ./examples
    ```
-   Note: The version of the goth `goth@v1.80.0` in the path above is subject to change in the future
+   Note: The second command navigates to the appropriate `/examples` directory. Note that the specific version of Goth (`goth@v1.80.0`) in the directory path may change in the future, requiring an update to the command accordingly.
 
 Now open up your browser and go to [http://localhost:3000](http://localhost:3000) to see the example.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ through Twitter, Facebook, Google Plus etc.
 
 To run the example use either of the methods below ::
 
-1. Clone the source from GitHub - (copy and paste the whole command line block from below in the terminal)
+1. Clone the source from GitHub - (Copy and paste the following command block into your terminal.)
    ```text
    git clone git@github.com:markbates/goth.git
    cd goth/examples
@@ -101,7 +101,7 @@ To run the example use either of the methods below ::
 
 or use
 
-2. Get the repository as a dependency - (copy and paste the whole command line block from below in the terminal)
+2. Get the repository as a dependency - (Copy and paste the following command block into your terminal.)
    ```text
    go get github.com/markbates/goth
    cd $GOPATH/pkg/mod/github.com/markbates/goth@v1.80.0/examples

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Now open up your browser and go to [http://localhost:3000](http://localhost:3000
 
 Most likely error screen will appear for most of the options when clicked on. To actually use the different providers, please make sure you set environment variables before running the built Go program (example.exe in this case).
 
-Environment variables can be set using
+Environment variables can be set using following command in the terminal
 
 ```text
 export key=value


### PR DESCRIPTION
When I first stumbled on the repo and tried to run the various commands as a complete new user of the repo , I faced a lot of difficulties to run the example folder. 

Simplified that for anyone else steps are more detailed and clear and need no much self-exploration to get the examples to work when using the `go get` method.

Also, improved on how can one set the environment variables that are getting used with some context on where these key, value pairs can be gotten from by taking into the most trivial sign-in method - GOOGLE as the example.

Removed the $ from each command line so that the copy and paste in the terminal does not require any more deletion of  the $ in the line before hitting enter.

All these changes are bound to improve the new user experience and hence also build the confidence to explore and contribute to the repo in the future.